### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -3,11 +3,11 @@
 :source-highlighter: prettify
 :project_id: gs-centralized-configuration
 
-This guide walks you through the process of standing up, and consuming configuration from, the http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html[Spring Cloud Config Server]
+This guide walks you through the process of standing up, and consuming configuration from, the https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html[Spring Cloud Config Server]
 
 == What you'll build
 
-You'll setup a http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html[Config Server] and then build a client that consumes the configuration on startup and then _refreshes_ the configuration without restarting the client.
+You'll setup a https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html[Config Server] and then build a client that consumes the configuration on startup and then _refreshes_ the configuration without restarting the client.
 
 == What you'll need
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html ([https](https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html) result 200).
* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/actuator/refresh with 1 occurrences
* http://localhost:8080/message with 2 occurrences
* http://localhost:8888 with 1 occurrences
* http://localhost:8888/a-bootiful-client/default with 1 occurrences