### PR TITLE
Update Hoxton version and some other changes

### DIFF
--- a/complete/configuration-client/build.gradle
+++ b/complete/configuration-client/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'org.springframework.boot' version '2.3.2.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
 }
 
@@ -14,7 +14,7 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "Hoxton.M3")
+	set('springCloudVersion', "Hoxton.SR6")
 }
 
 dependencies {

--- a/complete/configuration-client/pom.xml
+++ b/complete/configuration-client/pom.xml
@@ -12,11 +12,11 @@
 	<artifactId>centralized-configuration-client</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>centralized-configuration-client</name>
-	<description>Demo project for Spring Boot</description>
+	<description>Demo project for Spring Cloud Config</description>
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Hoxton.M3</spring-cloud.version>
+		<spring-cloud.version>Hoxton.SR6</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/complete/configuration-client/src/main/java/com/example/configurationclient/ConfigurationClientApplication.java
+++ b/complete/configuration-client/src/main/java/com/example/configurationclient/ConfigurationClientApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.configurationclient;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/complete/configuration-client/src/test/java/com/example/configurationclient/ConfigurationClientApplicationTest.java
+++ b/complete/configuration-client/src/test/java/com/example/configurationclient/ConfigurationClientApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/complete/configuration-service/build.gradle
+++ b/complete/configuration-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'org.springframework.boot' version '2.3.2.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
 }
 
@@ -14,7 +14,7 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "Hoxton.M3")
+	set('springCloudVersion', "Hoxton.SR6")
 }
 
 dependencies {

--- a/complete/configuration-service/pom.xml
+++ b/complete/configuration-service/pom.xml
@@ -12,11 +12,11 @@
 	<artifactId>centralized-configuration-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>centralized-configuration-service</name>
-	<description>Demo project for Spring Boot</description>
+	<description>Demo project for Spring Cloud Config</description>
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Hoxton.M3</spring-cloud.version>
+		<spring-cloud.version>Hoxton.SR6</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/complete/configuration-service/src/main/java/com/example/configurationservice/ConfigurationServiceApplication.java
+++ b/complete/configuration-service/src/main/java/com/example/configurationservice/ConfigurationServiceApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.configurationservice;
 
 import org.springframework.boot.SpringApplication;

--- a/complete/configuration-service/src/test/java/com/example/configurationservice/ConfigurationServiceApplicationTest.java
+++ b/complete/configuration-service/src/test/java/com/example/configurationservice/ConfigurationServiceApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/initial/configuration-client/build.gradle
+++ b/initial/configuration-client/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'org.springframework.boot' version '2.3.2.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
 }
 
@@ -14,7 +14,7 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "Hoxton.M3")
+	set('springCloudVersion', "Hoxton.SR6")
 }
 
 dependencies {

--- a/initial/configuration-client/pom.xml
+++ b/initial/configuration-client/pom.xml
@@ -12,11 +12,11 @@
 	<artifactId>centralized-configuration-client</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>centralized-configuration-client</name>
-	<description>Demo project for Spring Boot</description>
+	<description>Demo project for Spring Cloud Config</description>
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Hoxton.M3</spring-cloud.version>
+		<spring-cloud.version>Hoxton.SR6</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/initial/configuration-client/src/main/java/com/example/centralizedconfigurationclient/CentralizedConfigurationClientApplication.java
+++ b/initial/configuration-client/src/main/java/com/example/centralizedconfigurationclient/CentralizedConfigurationClientApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.centralizedconfigurationclient;
 
 import org.springframework.boot.SpringApplication;

--- a/initial/configuration-client/src/test/java/com/example/centralizedconfigurationclient/CentralizedConfigurationClientApplicationTests.java
+++ b/initial/configuration-client/src/test/java/com/example/centralizedconfigurationclient/CentralizedConfigurationClientApplicationTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.centralizedconfigurationclient;
 
 import org.junit.jupiter.api.Test;

--- a/initial/configuration-service/build.gradle
+++ b/initial/configuration-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'org.springframework.boot' version '2.3.2.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
 }
 
@@ -14,7 +14,7 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "Hoxton.M3")
+	set('springCloudVersion', "Hoxton.SR6")
 }
 
 dependencies {

--- a/initial/configuration-service/pom.xml
+++ b/initial/configuration-service/pom.xml
@@ -12,11 +12,11 @@
 	<artifactId>centralized-configuration-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>centralized-configuration-service</name>
-	<description>Demo project for Spring Boot</description>
+	<description>Demo project for Spring Cloud Config</description>
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Hoxton.M3</spring-cloud.version>
+		<spring-cloud.version>Hoxton.SR6</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/initial/configuration-service/src/main/java/com/example/centralizedconfigurationservice/CentralizedConfigurationServiceApplication.java
+++ b/initial/configuration-service/src/main/java/com/example/centralizedconfigurationservice/CentralizedConfigurationServiceApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.centralizedconfigurationservice;
 
 import org.springframework.boot.SpringApplication;

--- a/initial/configuration-service/src/test/java/com/example/centralizedconfigurationservice/CentralizedConfigurationServiceApplicationTests.java
+++ b/initial/configuration-service/src/test/java/com/example/centralizedconfigurationservice/CentralizedConfigurationServiceApplicationTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.centralizedconfigurationservice;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Update the Hoxton version to SR6, add copyright statements to classes
that didn't have them (and set the year to 2020 for all of them), and
other changes to keep things current.

Credit to  Said Boudjelda (@bmscomp on Github).